### PR TITLE
:tada: Upgrade of the Robots.txt file

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Disallow: /app/api/
+Disallow: /gpts/
 Sitemap: https://wiseduckdev.vercel.app/sitemap.xml
+


### PR DESCRIPTION
In order to prevent the navigators to index the gpts page and all affiliated pages until the domain name is changed